### PR TITLE
Prevent effect from running on every render

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,7 +17,7 @@ const RevenueCounter = () => {
     calculateRevenue();
     const interval = setInterval(calculateRevenue, 100);
     return () => clearInterval(interval);
-  }, [START_DATE]);
+  }, []);
 
   const formatRevenue = (amount: number) => {
     return new Intl.NumberFormat('en-US', {


### PR DESCRIPTION
Awesome project! Thanks for building and deploying this. :)

Including `START_DATE` in the `useEffect` dependency array causes the effect to run on every render, since `START_DATE` is being reinitialized every time the component rerenders.

That means that right now, every 100 milliseconds the value updates, the interval is cleared, the effect runs, creates a new interval, etc.

An empty dependency array tells react to run it exactly once, which is all that you need.